### PR TITLE
Fixed flash not showing for reCAPTCHA failures.

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -10,7 +10,7 @@ class ContactsController < ContactUs::ContactsController
 			  		redirect_to(root_path)
 			  	end
 			else
-			  	flash[:error] = t('contact_us.notices.error')
+				flash[:alert] = t('contact_us.notices.error')
 			  	render_new_page
 			end
 		else
@@ -22,7 +22,7 @@ class ContactsController < ContactUs::ContactsController
 			  		redirect_to(root_path)
 			  	end
 			else
-			  	flash[:error] = t('contact_us.notices.error')
+				flash[:alert] = t('contact_us.notices.error')
 			  	render_new_page
 			end
 		end		


### PR DESCRIPTION
If the user does not enter a valid reCAPTCHA then no message is
displayed. The problem seemed to be with
app/controllers/contacts_controller.rb which sets flash values
with the key :error. According to the Rails documentation on
the [flash](http://guides.rubyonrails.org/action_controller_overview.html#the-flash),
only :notice and :alert are supported:

> Note that it is also possible to assign a flash message as part
> of the redirection. You can assign :notice, :alert or the
> general purpose :flash:

Replaced flash[:error] with flash[:alert] so the flashes appear
on the title screen.