### PR TITLE
Set htmltoword version to 0.1.8.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'validate_url'
 
 gem 'thin'
 gem 'wicked_pdf'
-gem 'htmltoword'
+gem 'htmltoword', '0.1.8'
 gem 'feedzirra', '0.5.0'
 
 # To use ActiveModel has_secure_password


### PR DESCRIPTION
Exporting as a Word document (docx) raises the error:

    No such file or directory - /disk/ssi-dev0/home/mjj/.rvm/gems/ruby-2.0.0-p247/gems/htmltoword-0.2.0/lib/htmltoword/xslt/html_to_wordml.xslt

Looking at the gem on both SL6, and a fresh Ruby and gem install under an Ubuntu server, showed there was no xslt file e.g. for Ubuntu:

    $ ls /var/lib/gems/1.9.1/gems/htmltoword-0.2.0/lib/
    lib  Rakefile  README.md    $ ls /var/lib/gems/1.9.1/gems/htmltoword-0.2.0/lib/htmltoword
    action_controller.rb  document.rb           version.rb
    configuration.rb      htmltoword_helper.rb

However, the [0.2.0 tag](https://github.com/nickfrandsen/htmltoword/tree/v0.2.0/lib/htmltoword/xslt) on GitHub and the [0.2.0 zip](https://github.com/nickfrandsen/htmltoword/archive/v0.2.0.zip) both have htmltoword-0.2.0/lib/htmltoword/xslt with the xslt file.

Trying with the previous version, 0.1.8, gives:

    $ ls /var/lib/gems/1.9.1/gems/htmltoword-0.1.8/xslt/
    html_to_wordml.xslt  style2.xslt

Updating the DMPonline Gemfile to specifically use 0.1.8

    gem 'htmltoword', '0.1.8'

and running:

    $ bundle update

sorts this problem.

Another user of htmltoword 0.2.0 has raised this as an [issue](https://github.com/nickfrandsen/htmltoword/issues/33).