### PR TITLE
Present Shibboleth-specific content only if config.shibboleth_enabled is...

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -61,6 +61,7 @@
 		</table>
 		<br />
 		<p>
+                <% if Rails.application.config.shibboleth_enabled %>
 			<% if resource.shibboleth_id.nil? || resource.shibboleth_id.length == 0 then %>
 				<%= link_to t("helpers.shibboleth_to_link_text"), user_omniauth_shibboleth_path, :class => "a-orange" %>
 			<% else %>
@@ -69,6 +70,7 @@
                     <%= t("helpers.shibboleth_unlink_label")%>
                 </a>
 			<% end %>
+                <% end %>
 		</p>
 		<br />
 		<div class="div_clear">

--- a/app/views/shared/_login_form.html.erb
+++ b/app/views/shared/_login_form.html.erb
@@ -20,11 +20,13 @@
 	<li>
 		<%= f.submit t('helpers.sign_in'), :class => "btn btn-primary" %>
 	</li>
+        <% if Rails.application.config.shibboleth_enabled %>
 	<li>
 		<div class="institution_login_link">
 			<%= link_to t('helpers.institution_sing_in_link'), user_omniauth_shibboleth_path, :class => "a-orange" %>
 			<%= t('helpers.institution_sing_in')%>
 		</div>
 	</li>
+        <% end %>
 </ul>
 <% end %>


### PR DESCRIPTION
Present Shibboleth-specific content only if config.shibboleth_enabled is true.
config/application.rb defines a config.shibboleth_enabled flag._login_form.html.erb and edit.html.erb updated to access the value of this flag, via the reference Rails.application.config.shibboleth_enabled, and so present Shibboleth-specific content only if this flag is set to true.
