### PR TITLE
Made files DMP-agnostic

### DIFF
--- a/app/views/static_pages/help.html.erb
+++ b/app/views/static_pages/help.html.erb
@@ -19,16 +19,16 @@
 
 <div id="project-tabs" class="nav-project-tabs">
 	<ul class="nav nav-tabs" data-tabs="tabs">
-		<li class="active"><%= link_to t('help_page.tab_1'), "#DMPonlinehelp", :data => { :toggle => "tab"} %></li>
-        <li><%= link_to t('help_page.tab_2'), "#DMPhelp", :data => { :toggle => "tab"} %></li>
+		<li class="active"><%= link_to t('help_page.tab_1'), "#ToolHelp", :data => { :toggle => "tab"} %></li>
+        <li><%= link_to t('help_page.tab_2'), "#PlanningHelp", :data => { :toggle => "tab"} %></li>
 	</ul>
 </div>
 <div class="dmp_details_body">
 	<div id="my-tab-content" class="tab-content">
-		<div class="tab-pane active" id="DMPonlinehelp">
+		<div class="tab-pane active" id="ToolHelp">
 			<%= raw t('help_page.body_text_tab_1_html')%>
 		</div>	
-		<div class="tab-pane" id="DMPhelp">
+		<div class="tab-pane" id="PlanningHelp">
 			<%= raw t('help_page.body_text_tab_2_html')%>
 		</div>		
 	</div>

--- a/app/views/user_mailer/permissions_change_notification.html.erb
+++ b/app/views/user_mailer/permissions_change_notification.html.erb
@@ -9,4 +9,4 @@ elsif @project_group.access_level == 3 then
 end
 %>
 
-<p>Your permissions relating to the DMP "<%= link_to @project_group.project.title, project_path(@project_group.project, :only_path => false) %>" have changed. You now have <%= access_level %> access.</p>
+<p>Your permissions relating to "<%= link_to @project_group.project.title, project_path(@project_group.project, :only_path => false) %>" have changed. You now have <%= access_level %> access.</p>

--- a/app/views/user_mailer/project_access_removed_notification.html.erb
+++ b/app/views/user_mailer/project_access_removed_notification.html.erb
@@ -1,3 +1,3 @@
 <p>Hello <%= @user.name %></p>
 
-<p>Your access to the DMP "<%= @project.title %>" has been removed.</p>
+<p>Your access to "<%= @project.title %>" has been removed.</p>

--- a/app/views/user_mailer/sharing_notification.html.erb
+++ b/app/views/user_mailer/sharing_notification.html.erb
@@ -9,4 +9,4 @@ elsif @project_group.access_level == 3 then
 end
 %>
 
-<p>You have been given <%= access_level %> access to the DMP "<%= link_to @project_group.project.title, project_path(@project_group.project, :only_path => false) %>".</p>
+<p>You have been given <%= access_level %> access to "<%= link_to @project_group.project.title, project_path(@project_group.project, :only_path => false) %>".</p>


### PR DESCRIPTION
1.
Changed HTML link anchors in app/views/static_pages/help.html.erb to be DMP agnostic (DMPonlinehelp renamed to ToolHelp and DMPhelp to PlanningHelp).
2.
Changed the phrases 'to the DMP NNNN' in the e-mail content files:

    app/views/user_mailer/permissions_change_notification.html.erb
    app/views/user_mailer/project_access_removed_notification.html.erb
    app/views/user_mailer/sharing_notification.html.erb

to 'to NNNN' so these files are DMP-agnostic.