### PR TITLE
Remove confusing instructions from README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -26,20 +26,7 @@ DMPonline is a Ruby on Rails application and you will need to have Ruby 2.0.0p24
 
 Further details on how to install Ruby on Rails applications are available from the Ruby on Rails site, http://rubyonrails.org
 
-
-== Getting Started
-
-1. At the command prompt, create a new Rails application:
-       <tt>rails new myapp</tt> (where <tt>myapp</tt> is the application name)
-
-2. Change directory to <tt>myapp</tt> and start the web server:
-       <tt>cd myapp; rails server</tt> (run with --help for options)
-
-3. Go to http://localhost:3000/ and you'll see:
-       "Welcome aboard: You're riding Ruby on Rails!"
-
-4. Follow the guidelines to start developing your application. You can find
-the following resources handy:
+You may also find the following resources handy:
 
 * The Getting Started Guide: http://guides.rubyonrails.org/getting_started.html
 * Ruby on Rails Tutorial Book: http://www.railstutorial.org/


### PR DESCRIPTION
Looks like some of the "Getting started" instructions related to starting a new Rails app rather than getting started with DMPonline.