### PR TITLE
Commented out old AdminUser reference in DB migration file

### DIFF
--- a/db/migrate/20130708092900_devise_create_admin_users.rb
+++ b/db/migrate/20130708092900_devise_create_admin_users.rb
@@ -2,7 +2,7 @@ class DeviseCreateAdminUsers < ActiveRecord::Migration
   def migrate(direction)
     super
     # Create a default user
-    AdminUser.create!(:email => 'admin@example.com', :password => 'password', :password_confirmation => 'password') if direction == :up
+    #AdminUser.create!(:email => 'admin@example.com', :password => 'password', :password_confirmation => 'password') if direction == :up
   end
 
   def change


### PR DESCRIPTION
Commented out an old reference to an AdminUser model that no longer exists. This was preventing users (reported via the listserv by Herbert Nguruwe) from downloading the repo and running an initial db:migrate. 

The referenced table is dropped in a later migration script so there is no risk with this change. The fix is already a part of the DMPRoadmap/Roadmap repo.