### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem 'rails', '3.2.22'
 gem 'uglifier'
 gem 'less-rails'
-gem 'twitter-bootstrap-rails'
+gem 'twitter-bootstrap-rails', '2.2.8'
 gem 'sass-rails',   '~> 3.2.3'
 gem 'sass' 
 gem 'therubyracer', '0.11.4', platforms: :ruby


### PR DESCRIPTION
twitter-bootstrap-rails Fails in the newest version. 2.2.8 should be used.